### PR TITLE
Breaking: move to JSONStream. remove multibyte option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CHANGELOG	:= $(TOOLS)/changelog.js
 # Files and globs
 #
 PACKAGE_JSON	:= $(ROOT)/package.json
-SHRINKWRAP	:= $(ROOT)/npm-shrinkwrap.json
+PACKAGE_LOCK	:= $(ROOT)/package-lock.json
 GITHOOKS	:= $(wildcard $(GITHOOKS_SRC)/*)
 LCOV		:= $(COVERAGE)/lcov.info
 ALL_FILES	:= $(shell find $(ROOT) \
@@ -99,13 +99,7 @@ codestyle-fix: $(NODE_MODULES) $(JSCS) $(ALL_FILES) ## Run code style checker wi
 
 .PHONY: nsp
 nsp: $(NODE_MODULES) $(NSP) $(NSP_BADGE) ## Run nsp. Shrinkwraps dependencies, checks for vulnerabilities.
-ifeq ($(wildcard $(SHRINKWRAP)),)
-	@$(NPM) shrinkwrap --dev
 	@($(NSP) check) | $(NSP_BADGE)
-	@rm $(SHRINKWRAP)
-else
-	@($(NSP) check) | $(NSP_BADGE)
-endif
 
 
 .PHONY: prepush

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The major caveat is that the reconstructed POJO must be able to fit in memory.
 If the reconstructed POJO cannot be stored in memory, then it may be time to
 reconsider the way these large objects are being transported and processed.
 
-This module currently uses [stream-json](https://github.com/uhop/stream-json/)
-for parsing, and
+This module currently uses
+[JSONStream](https://github.com/dominictarr/JSONStream) for parsing, and
 [json-stream-stringify](https://github.com/Faleij/json-stream-stringify) for
 stringification.
 
@@ -77,17 +77,10 @@ stringifyStream.on('data', function(strChunk) {
 });
 ```
 
-IMPORTANT: Due to limitations in the implementation, directly calling
-`write()` on the streams may cause unexpected behavior. For maximum
-compatibility, use the Node.js streams `pipe()` method.
-
 
 ## API
 
-### createParseStream(opts)
-
-* `opts` {Object} an options object
-* `opts.multibyte` {Boolean} handle multibyte chars, defaults to true
+### createParseStream()
 
 __Returns__: {Stream} a JSON.parse stream
 
@@ -102,8 +95,8 @@ __Returns__: {Stream} a JSON.stringify stream
 An async JSON.parse using the same underlying stream implementation, but with
 a callback interface.
 
-* `opts` {Object} an options object passed to `createParseStream`
-* `opts.body` {Object} the string to be parsed
+* `opts` {Object} an options object
+* `opts.body` {String} the string to be parsed
 * `callback` {Function} a callback object
 
 __Returns__: {Object} the parsed object
@@ -112,7 +105,7 @@ __Returns__: {Object} the parsed object
 An async JSON.stringify using the same underlying stream implementation, but
 with a callback interface.
 
-* `opts` {Object} an options object passed to `createStringifyStream`
+* `opts` {Object} an options object
 * `opts.body` {Object} the object to be stringified
 * `callback` {Function} a callback object
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const stream = require('stream');
 const assert = require('assert-plus');
 const JSONStream = require('JSONStream');
 const miss = require('mississippi');
+const once = require('once').strict;
 const stringifyStreamFactory = require('json-stream-stringify');
 
 
@@ -86,13 +87,14 @@ function parse(opts, callback) {
     assert.func(callback, 'callback');
 
     const parseStream = createParseStream();
+    const cb = once(callback);
 
     parseStream.on('data', function(data) {
-        return callback(null, data);
+        return cb(null, data);
     });
 
     parseStream.on('error', function(err) {
-        return callback(err);
+        return cb(err);
     });
 
     parseStream.end(opts.body);
@@ -115,6 +117,7 @@ function stringify(opts, callback) {
     let stringified = '';
     const stringifyStream = createStringifyStream(opts);
     const passthroughStream = new stream.PassThrough();
+    const cb = once(callback);
 
     // setup the passthrough stream as a sink
     passthroughStream.on('data', function(chunk) {
@@ -122,13 +125,13 @@ function stringify(opts, callback) {
     });
 
     passthroughStream.on('end', function() {
-        return callback(null, stringified);
+        return cb(null, stringified);
     });
 
     // don't know what errors stringify stream may emit, but pass them back
     // up.
     stringifyStream.on('error', function(err) {
-        return callback(err);
+        return cb(err);
     });
 
     stringifyStream.pipe(passthroughStream);

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const stream = require('stream');
 
 // external modules
 const assert = require('assert-plus');
+const intoStream = require('into-stream');
 const JSONStream = require('JSONStream');
 const miss = require('mississippi');
 const once = require('once').strict;
@@ -86,6 +87,7 @@ function parse(opts, callback) {
     assert.string(opts.body, 'opts.body');
     assert.func(callback, 'callback');
 
+    const sourceStream = intoStream(opts.body);
     const parseStream = createParseStream();
     const cb = once(callback);
 
@@ -97,7 +99,7 @@ function parse(opts, callback) {
         return cb(err);
     });
 
-    parseStream.end(opts.body);
+    sourceStream.pipe(parseStream);
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,104 +4,46 @@
 const stream = require('stream');
 
 // external modules
-const Assembler = require('stream-json/utils/Assembler');
 const assert = require('assert-plus');
-const JSONParseStream = require('stream-json/Combo');
-const through2 = require('through2');
+const JSONStream = require('JSONStream');
+const miss = require('mississippi');
 const stringifyStreamFactory = require('json-stream-stringify');
-const utf8Stream = require('utf8-stream');
 
 
 /**
- * Create a JSON.parse that uses a stream interface. The underlying stream-json
- * module used to do the parsing is actually a combo stream that combines 3
- * streams into a singular stream. It's a combo stream in the sense that the
- * code is combined (generated?) into a single stream to avoid overhead of
- * piping together 3 separate streams:
- *   * Parser (reading in raw strings)
- *   * Streamer (converts token into SAX-like event stream)
- *   * Packer (which assembles individual JS primitives from parsed chunks).
- *
- * Finally, an "Assembler" class is used to reconstruct the full POJO by
- * assembling the individual JSON chunks. The caveat is that the process must
- * be able to hold the fully reconstructed object in memory.
- *
- * However, since the assembler is not a stream and works outside the streams
- * themselves, we must create a wrapper stream that that encapsulates the
- * execution of the 3 internal streams plus the assembler. that way external
- * consumers can expect to work with the standard stream events like 'data or
- * 'end'. the wrapper stream can be thought of as an accumulator of the JSON
- * chunks that will emit the fully constructed POJO once it is complete. as an
- * accumulator, certain stream concepts like backpressure don't apply since it
- * isn't emitting any data until the reconstruction of the POJO is complete.
+ * Create a JSON.parse that uses a stream interface. The underlying
+ * implementation is handled by JSONStream. This is merely a thin wrapper for
+ * convenience that handles the reconstruction/accumulation of each
+ * individually parsed field.
  *
  * The advantage of this approach is that by also using a streams interface,
  * any JSON parsing or stringification of large objects won't block the CPU.
  * @public
- * @param {Object} [options] an options object
- * @param {Object} [options.multibyte] when true, support multibyte. defaults
- * to true.
  * @function createParseStream
  * @return {Stream}
  */
-function createParseStream(options) {
+function createParseStream() {
 
-    const opts = Object.assign({
-        multibyte: true
-    }, options);
-
-    assert.optionalObject(opts, 'opts');
-    assert.optionalBool(opts.multibyte, 'opts.multibyte');
-
-    const assembler = new Assembler();
-    const parseStream = new JSONParseStream({
-        packKeys: true,
-        packStrings: true,
-        packNumbers: true
-    });
-    const wrapperStream = through2.obj(function(chunk, enc, callback) {
-        this.push(chunk);
-        return callback();
-    });
-    let redirected = false;
-
-    // when a read stream is piped in, redirect data from the wrapper stream to
-    // the real underlying json stream. redirection can only be done at the
-    // time of being hooked up, since we need the source stream.
-    wrapperStream.on('pipe', function wrapperStreamOnPipe(source) {
-        // as this is an accumulator stream, attempting to pipe in more than
-        // one source stream is a user error and should be fatal.
-        if (redirected === true) {
-            throw new Error(
-                'big-json parseStream cannot accept multiple sources!'
-            );
+    // when the parse stream gets chunks of data, it is an object with key/val
+    // fields. accumulate the parsed fields.
+    const accumulator = {};
+    const parseStream = JSONStream.parse('$*');
+    const wrapperStream = miss.through.obj(
+        function write(chunk, enc, cb) {
+            parseStream.write(chunk);
+            return cb();
+        },
+        function flush(cb) {
+            parseStream.on('end', function() {
+                return cb(null, accumulator);
+            });
+            parseStream.end();
         }
+    );
 
-        source.unpipe(this);
-
-        // pipe the stream, prepend with multibyte if necessary. utf8stream can
-        // never error, so no need to handle errors here.
-        if (opts.multibyte === true) {
-            this.transformStream = source.pipe(utf8Stream()).pipe(parseStream);
-        } else {
-            this.transformStream = source.pipe(parseStream);
-        }
-        redirected = true;
-    });
-
-    // when the parse stream gets chunks of data, through them into the
-    // assembler.  the assembler is basically a pointer to the current
-    // object/scope from which a JSON chunk was parsed.
+    // for each chunk parsed, add it to the accumulator
     parseStream.on('data', function(chunk) {
-        if (assembler[chunk.name]) {
-            assembler[chunk.name](chunk.value);
-        }
-    });
-
-    // on completion of parsing, write the completed pojo to the wrapper stream
-    // and end the stream.
-    parseStream.on('end', function() {
-        wrapperStream.end(assembler.current);
+        accumulator[chunk.key] = chunk.value;
     });
 
     // make sure error is forwarded on to wrapper stream.
@@ -143,22 +85,17 @@ function parse(opts, callback) {
     assert.string(opts.body, 'opts.body');
     assert.func(callback, 'callback');
 
-    const writeStream = through2.obj(function(chunk, enc, cb) {
-        this.push(chunk);
-        return cb();
-    });
-    const parseStream = createParseStream(opts);
+    const parseStream = createParseStream();
 
-    parseStream.on('data', function(pojo) {
-        return callback(null, pojo);
+    parseStream.on('data', function(data) {
+        return callback(null, data);
     });
 
     parseStream.on('error', function(err) {
         return callback(err);
     });
 
-    writeStream.pipe(parseStream);
-    writeStream.end(opts.body);
+    parseStream.end(opts.body);
 }
 
 
@@ -168,14 +105,13 @@ function parse(opts, callback) {
  * @public
  * @param {Object} opts options to pass to stringify stream
  * @param {Function} callback a callback function
- * @function parse
+ * @function stringify
  * @return {Object} the parsed JSON object
  */
 function stringify(opts, callback) {
     assert.object(opts, 'opts');
     assert.func(callback, 'callback');
 
-    let done = false;
     let stringified = '';
     const stringifyStream = createStringifyStream(opts);
     const passthroughStream = new stream.PassThrough();
@@ -186,17 +122,12 @@ function stringify(opts, callback) {
     });
 
     passthroughStream.on('end', function() {
-        // if we didn't already error and exit
-        if (done === false) {
-            return callback(null, stringified);
-        }
-        return null;
+        return callback(null, stringified);
     });
 
     // don't know what errors stringify stream may emit, but pass them back
     // up.
     stringifyStream.on('error', function(err) {
-        done = true;
         return callback(err);
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1421,6 +1421,15 @@
         "through": "2.3.8"
       }
     },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
+      }
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -2307,6 +2316,11 @@
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "JSV": {
       "version": "4.0.2",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/JSV/-/JSV-4.0.2.tgz",
@@ -17,9 +26,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha1-kRy1PgNoB88Pp3jcXTcPvYZCRtc=",
+      "version": "5.2.1",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha1-MXrHghgmwixwLWYYmrg1lnXxNdc=",
       "dev": true
     },
     "acorn-jsx": {
@@ -59,6 +68,12 @@
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
@@ -175,6 +190,30 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "babel-runtime": {
@@ -290,20 +329,38 @@
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.5"
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.3.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "4.5.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "check-error": {
@@ -379,6 +436,15 @@
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         }
       }
     },
@@ -422,9 +488,9 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -452,10 +518,13 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
-      "dev": true
+      "version": "2.9.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "comment-parser": {
       "version": "0.3.2",
@@ -476,7 +545,6 @@
       "version": "1.6.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
@@ -500,7 +568,7 @@
       "integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
       "dev": true,
       "requires": {
-        "js-yaml": "3.6.1",
+        "js-yaml": "3.10.0",
         "lcov-parse": "0.0.10",
         "log-driver": "1.2.5",
         "minimist": "1.2.0",
@@ -561,6 +629,11 @@
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
       "dev": true
     },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/dashdash/-/dashdash-1.14.1.tgz",
@@ -591,7 +664,7 @@
       "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.5"
       }
     },
     "deep-equal": {
@@ -692,6 +765,17 @@
         "domelementtype": "1.3.0"
       }
     },
+    "duplexify": {
+      "version": "3.5.1",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/duplexify/-/duplexify-3.5.1.tgz",
+      "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -700,6 +784,14 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "requires": {
+        "once": "1.4.0"
       }
     },
     "entities": {
@@ -751,6 +843,12 @@
         "source-map": "0.2.0"
       },
       "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
         "estraverse": {
           "version": "1.9.3",
           "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/estraverse/-/estraverse-1.9.3.tgz",
@@ -760,9 +858,9 @@
       }
     },
     "eslint": {
-      "version": "4.9.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/eslint/-/eslint-4.9.0.tgz",
-      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "version": "4.11.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/eslint/-/eslint-4.11.0.tgz",
+      "integrity": "sha1-OajIK8CjeDrfWjn6J/3Z02+smjQ=",
       "dev": true,
       "requires": {
         "ajv": "5.3.0",
@@ -773,7 +871,7 @@
         "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -786,7 +884,7 @@
         "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -802,68 +900,6 @@
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
         "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "eslint-scope": {
@@ -877,19 +913,19 @@
       }
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esquery": {
@@ -1031,6 +1067,15 @@
         "write": "0.2.1"
       }
     },
+    "flush-write-stream": {
+      "version": "1.0.2",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1046,6 +1091,15 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       }
     },
     "fs.realpath": {
@@ -1365,52 +1419,6 @@
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "invert-kv": {
@@ -1532,7 +1540,7 @@
         "esprima": "2.7.3",
         "glob": "5.0.15",
         "handlebars": "4.0.11",
-        "js-yaml": "3.6.1",
+        "js-yaml": "3.10.0",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "once": "1.4.0",
@@ -1542,6 +1550,12 @@
         "wordwrap": "1.0.0"
       },
       "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/glob/-/glob-5.0.15.tgz",
@@ -1579,13 +1593,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "version": "3.10.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
-        "esprima": "2.7.3"
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -1635,14 +1649,24 @@
         "xmlbuilder": "3.1.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
         },
         "glob": {
           "version": "5.0.15",
@@ -1685,6 +1709,15 @@
           "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pathval/-/pathval-0.1.1.tgz",
           "integrity": "sha1-CPkRzcqczllCiA2ngXvAtyO2bYI=",
           "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "1.0.4",
@@ -1739,14 +1772,11 @@
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
-    "json-stable-stringify": {
+    "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stream-stringify": {
       "version": "1.5.1",
@@ -1759,12 +1789,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
     "jsonlint": {
       "version": "1.6.2",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/jsonlint/-/jsonlint-1.6.2.tgz",
@@ -1774,6 +1798,11 @@
         "JSV": "4.0.2",
         "nomnom": "1.8.1"
       }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1931,6 +1960,23 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "mississippi": {
+      "version": "1.3.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mississippi/-/mississippi-1.3.0.tgz",
+      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "duplexify": "3.5.1",
+        "end-of-stream": "1.4.0",
+        "flush-write-stream": "1.0.2",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "1.0.3",
+        "pumpify": "1.3.5",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1966,6 +2012,12 @@
         "supports-color": "4.4.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+          "dev": true
+        },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-4.4.0.tgz",
@@ -2089,31 +2141,11 @@
         "yargs": "9.0.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
         },
         "cliui": {
           "version": "3.2.0",
@@ -2148,13 +2180,13 @@
             "number-is-nan": "1.0.1"
           }
         },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "yargs": {
@@ -2202,7 +2234,6 @@
       "version": "1.4.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -2292,6 +2323,16 @@
         "p-limit": "1.1.0"
       }
     },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "requires": {
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/parse-json/-/parse-json-2.2.0.tgz",
@@ -2300,11 +2341,6 @@
       "requires": {
         "error-ex": "1.3.1"
       }
-    },
-    "parser-toolkit": {
-      "version": "0.0.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/parser-toolkit/-/parser-toolkit-0.0.5.tgz",
-      "integrity": "sha1-7EthcpyGMYtW6pcb+6azxnLWLAE="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -2419,6 +2455,25 @@
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "pump": {
+      "version": "1.0.3",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "once": "1.4.0"
+      }
+    },
+    "pumpify": {
+      "version": "1.3.5",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/pumpify/-/pumpify-1.3.5.tgz",
+      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+      "requires": {
+        "duplexify": "3.5.1",
+        "inherits": "2.0.3",
+        "pump": "1.0.3"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -2749,13 +2804,19 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
-    "stream-json": {
-      "version": "0.5.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/stream-json/-/stream-json-0.5.2.tgz",
-      "integrity": "sha1-9CVsDvGpBfLvLUc3BrSz/4J2U88=",
+    "stream-each": {
+      "version": "1.2.2",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha1-joxGP5HaiZF3h2WHP+TZYNj2Fr0=",
       "requires": {
-        "parser-toolkit": "0.0.5"
+        "end-of-stream": "1.4.0",
+        "stream-shift": "1.0.0"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "string-width": {
       "version": "2.1.1",
@@ -2765,23 +2826,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "string_decoder": {
@@ -2799,12 +2843,20 @@
       "dev": true
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -2841,48 +2893,11 @@
       "dev": true,
       "requires": {
         "ajv": "5.3.0",
-        "ajv-keywords": "2.1.0",
+        "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ajv-keywords": {
-          "version": "2.1.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "text-table": {
@@ -2894,8 +2909,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.3",
@@ -2968,16 +2982,15 @@
       }
     },
     "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "version": "4.0.5",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI=",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -3012,37 +3025,6 @@
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
-    },
-    "utf8-stream": {
-      "version": "0.0.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/utf8-stream/-/utf8-stream-0.0.0.tgz",
-      "integrity": "sha1-Bc5BB/zq+JOiyDj+Y6HUI0VcH8Q=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3225,14 +3207,22 @@
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         }
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "wreck": {
       "version": "12.5.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "JSONStream": "^1.3.1",
     "assert-plus": "^1.0.0",
     "json-stream-stringify": "^1.5.1",
-    "mississippi": "^1.3.0"
+    "mississippi": "^1.3.0",
+    "once": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,9 @@
     "nsp": "^3.1.0"
   },
   "dependencies": {
+    "JSONStream": "^1.3.1",
     "assert-plus": "^1.0.0",
     "json-stream-stringify": "^1.5.1",
-    "stream-json": "^0.5.2",
-    "through2": "^2.0.3",
-    "utf8-stream": "0.0.0"
+    "mississippi": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "JSONStream": "^1.3.1",
     "assert-plus": "^1.0.0",
+    "into-stream": "^3.1.0",
     "json-stream-stringify": "^1.5.1",
     "mississippi": "^1.3.0",
     "once": "^1.4.0"

--- a/test/index.js
+++ b/test/index.js
@@ -189,8 +189,7 @@ describe('big-json', function() {
             parseStream.on('error', function(err) {
                 assert.ok(err);
                 assert.equal(err.name, 'Error');
-                assert.equal(err.message, 'Invalid JSON (Unexpected "\\n" ' +
-                    'at position 27 in state STOP)');
+                assert.include(err.message, 'Invalid JSON');
                 return done();
             });
 

--- a/test/index.js
+++ b/test/index.js
@@ -195,6 +195,30 @@ describe('big-json', function() {
 
             readStream.pipe(parseStream);
         });
+
+
+        it('should handle multibyte keys and vals', function(done) {
+            const parseStream = json.createParseStream();
+
+            parseStream.on('data', function(pojo) {
+                assert.deepEqual(pojo, {
+                    '遙': '遙遠未來的事件'
+                });
+                return done();
+            });
+
+            parseStream.write('{ "');
+            parseStream.write(Buffer([ 0xe9, 0x81 ]));
+            parseStream.write(Buffer([ 0x99 ]));
+            parseStream.write('":"');
+            parseStream.write(Buffer([ 0xe9, 0x81 ]));
+            parseStream.write(Buffer([ 0x99, 0xe9, 0x81, 0xa0, 0xe6 ]));
+            parseStream.write(Buffer([ 0x9c, 0xaa, 0xe4, 0xbe ]));
+            parseStream.write(Buffer([ 0x86, 0xe7, 0x9a, 0x84,
+                                     0xe4, 0xba, 0x8b ]));
+            parseStream.write(Buffer([ 0xe4, 0xbb, 0xb6 ]));
+            parseStream.end('"}');
+        });
     });
 
 


### PR DESCRIPTION
This moves this module to JSONStream. 

The granularity provided by [json-stream](https://github.com/uhop/stream-json/) is nice but was causing parse operations to take much longer than expected. It looks like JSONStream by default using the `$*` path separates on top level fields, which may be "good enough" for most big JSON cases.

There might be something interesting around customizing the JSONStream path to target parts of the big POJO where known tokens are too large. Could be something for 2.x. 

`opts.multibyte` is also no longer necessary since JSONStream's underlying [jsonparse](https://github.com/creationix/jsonparse) handles it already.