### PR TITLE
Support parsing from Buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,13 +81,21 @@ function createStringifyStream(opts) {
  * stream based JSON.parse. async function signature to abstract over streams.
  * @public
  * @param {Object} opts options to pass to parse stream
- * @param {String} opts.body string to parse
+ * @param {String|Buffer} opts.body string or buffer to parse
  * @param {Function} callback a callback function
  * @return {Object} the parsed JSON object
  */
 function _parse(opts, callback) {
     assert.object(opts, 'opts');
-    assert.string(opts.body, 'opts.body');
+    try {
+        assert.string(opts.body, 'opts.body');
+    } catch (e) {
+        if (e instanceof assert.AssertionError) {
+            assert.buffer(opts.body, 'opts.body');
+        } else {
+            throw e;
+        }
+    }
     assert.func(callback, 'callback');
 
     const sourceStream = intoStream(opts.body);

--- a/test/index.js
+++ b/test/index.js
@@ -314,5 +314,15 @@ describe('big-json', function() {
                 })
                 .catch(done);
         });
+
+        it('should return err if body is neither string nor buffer', function(done) {
+            json.parse({
+                body: POJO
+            }).catch(function(err) {
+                assert.ok(err);
+                assert.include(err.message, 'opts.body');
+                return done();
+            });
+        });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -291,6 +291,7 @@ describe('big-json', function() {
                 }
             );
         });
+
         it('should return err in parse async (promise)', function(done) {
             json.parse({
                 body: fs
@@ -301,6 +302,17 @@ describe('big-json', function() {
                 assert.include(err.message, 'Invalid JSON (Unexpected');
                 return done();
             });
+        });
+
+        it('should parse (buffer)', function(done) {
+            json.parse({
+                body: Buffer.from(JSON.stringify(POJO))
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, POJO);
+                    return done();
+                })
+                .catch(done);
         });
     });
 });


### PR DESCRIPTION
I had the use-case where I wanted to use the high-level `parse` but didn't want to turn my buffer into a string first. The underlying `into-stream` can handle not only strings  but also buffers (and others) so I changed the input assertions and also added a test for it.