### PR TITLE
Optional Support for JSON Array (replacement for pr #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ stringifyStream.on('data', function(strChunk) {
 
 ## API
 
-### createParseStream()
+### createParseStream(isRootArray)
+
+* `isRootArray` {Boolean} if true, stream will parse to Array, otherwise to Object
 
 __Returns__: {Stream} a JSON.parse stream
 
@@ -94,10 +96,11 @@ An async JSON.parse using the same underlying stream implementation. If a
 callback is not passed, a promise is returned.
 
 * `opts` {Object} an options object
+* `opts.isRootArray` {Boolean} if true, function will return Array
 * `opts.body` {String} the string to be parsed
 * `callback` {Function} a callback object
 
-__Returns__: {Object} the parsed object
+__Returns__: {Object | Array} the parsed JSON
 
 ### stringify(opts, [callback])
 An async JSON.stringify using the same underlying stream implementation. If a

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ const _stringifyPromisified = util.promisify(_stringify);
 function createParseStream() {
     // when the parse stream gets chunks of data, it is an object with key/val
     // fields. accumulate the parsed fields.
-    const accumulator = {};
+    let accumulator = {};
     const parseStream = JSONStream.parse('$*');
     const wrapperStream = through2.obj(
         function write(chunk, enc, cb) {
@@ -46,8 +46,20 @@ function createParseStream() {
         }
     );
 
+    const initAccumulator = function(chunk) {
+        if (typeof chunk.key === 'number') {
+            return [];
+        }
+        return {};
+    };
+
     // for each chunk parsed, add it to the accumulator
+    let dataChunkCounter = 0;
     parseStream.on('data', function(chunk) {
+        dataChunkCounter++;
+        if (dataChunkCounter === 1) {
+            accumulator = initAccumulator(chunk);
+        }
         accumulator[chunk.key] = chunk.value;
     });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,13 +25,14 @@ const _stringifyPromisified = util.promisify(_stringify);
  * The advantage of this approach is that by also using a streams interface,
  * any JSON parsing or stringification of large objects won't block the CPU.
  * @public
+ * @param {Boolean} isRootArray if true, stream will parse to Array, otherwise to Object
  * @function createParseStream
  * @return {Stream}
  */
-function createParseStream() {
+function createParseStream(isRootArray = false) {
     // when the parse stream gets chunks of data, it is an object with key/val
     // fields. accumulate the parsed fields.
-    let accumulator = {};
+    let accumulator = null;
     const parseStream = JSONStream.parse('$*');
     const wrapperStream = through2.obj(
         function write(chunk, enc, cb) {
@@ -46,19 +47,9 @@ function createParseStream() {
         }
     );
 
-    const initAccumulator = function(chunk) {
-        if (typeof chunk.key === 'number') {
-            return [];
-        }
-        return {};
-    };
-
-    // for each chunk parsed, add it to the accumulator
-    let dataChunkCounter = 0;
     parseStream.on('data', function(chunk) {
-        dataChunkCounter++;
-        if (dataChunkCounter === 1) {
-            accumulator = initAccumulator(chunk);
+        if (accumulator === null) {
+            accumulator = isRootArray ? [] : {};
         }
         accumulator[chunk.key] = chunk.value;
     });
@@ -93,9 +84,10 @@ function createStringifyStream(opts) {
  * stream based JSON.parse. async function signature to abstract over streams.
  * @public
  * @param {Object} opts options to pass to parse stream
+ * @param {Boolean} opts.isRootArray if true, function will return Array
  * @param {String|Buffer} opts.body string or buffer to parse
  * @param {Function} callback a callback function
- * @return {Object} the parsed JSON object
+ * @return {Object|Array} the parsed JSON
  */
 function _parse(opts, callback) {
     assert.object(opts, 'opts');
@@ -111,7 +103,7 @@ function _parse(opts, callback) {
     assert.func(callback, 'callback');
 
     const sourceStream = intoStream(opts.body);
-    const parseStream = createParseStream();
+    const parseStream = createParseStream(opts.isRootArray);
     const cb = once(callback);
 
     parseStream.on('data', function(data) {
@@ -131,10 +123,11 @@ function _parse(opts, callback) {
  * @public
  * @function parse
  * @param {Object} opts options to pass to parse stream
+ * @param {Boolean} opts.isRootArray if true, function will return Array
  * @param {String} opts.body string to parse
  * @param {Function} [callback] a callback function. if empty, returns a
  * promise.
- * @return {Object} the parsed JSON object
+ * @return {Object|Array} the parsed JSON
  */
 function parse(opts, callback) {
     // if more than one argument was passed, assume it's a callback based usage.

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,13 +81,21 @@ function createStringifyStream(opts) {
  * stream based JSON.parse. async function signature to abstract over streams.
  * @public
  * @param {Object} opts options to pass to parse stream
- * @param {String} opts.body string to parse
+ * @param {String|Buffer} opts.body string or buffer to parse
  * @param {Function} callback a callback function
  * @return {Object} the parsed JSON object
  */
 function _parse(opts, callback) {
     assert.object(opts, 'opts');
-    assert.string(opts.body, 'opts.body');
+    try {
+        assert.string(opts.body, 'opts.body');
+    } catch (e) {
+        if (e instanceof assert.AssertionError) {
+            assert.buffer(opts.body, 'opts.body');
+        } else {
+            throw e;
+        }
+    }
     assert.func(callback, 'callback');
 
     const sourceStream = intoStream(opts.body);

--- a/test/index.js
+++ b/test/index.js
@@ -324,5 +324,17 @@ describe('big-json', function() {
                 return done();
             });
         });
+
+        it('should parse root JSON array', function(done) {
+            const input = [{ key: 'value' }, { key: null }];
+            json.parse({
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, input);
+                    return done();
+                })
+                .catch(done);
+        });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -314,5 +314,15 @@ describe('big-json', function() {
                 })
                 .catch(done);
         });
+
+        it('should return err if body is neither string nor buffer', function(done) {
+            json.parse({
+                body: POJO
+            }).catch(function(err) {
+                assert.ok(err);
+                assert.include(err.message, 'opts.body');
+                return done();
+            });
+        });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -325,7 +325,51 @@ describe('big-json', function() {
             });
         });
 
-        it('should parse root JSON array', function(done) {
+        it('should parse root JSON Object as Object', function(done) {
+            const input = { 0: { key: 'value' }, 1: { key: null } };
+            json.parse({
+                isRootArray: false,
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, input);
+                    return done();
+                })
+                .catch(done);
+        });
+
+        it('should parse root JSON Object as Array', function(done) {
+            const input = { 0: { key: 'value' }, 1: { key: null } };
+            const expectedOutput = [{ key: 'value' }, { key: null }];
+            json.parse({
+                isRootArray: true,
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, expectedOutput);
+                    return done();
+                })
+                .catch(done);
+        });
+
+        it('should parse root JSON Array as Object', function(done) {
+            const input = [{ key: 'value' }, { key: null }];
+            const expectedOutput = {
+                0: { key: 'value' },
+                1: { key: null }
+            };
+            json.parse({
+                isRootArray: false,
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, expectedOutput);
+                    return done();
+                })
+                .catch(done);
+        });
+
+        it('should parse root JSON Array as Array', function(done) {
             const input = [{ key: 'value' }, { key: null }];
             json.parse({
                 isRootArray: true,

--- a/test/index.js
+++ b/test/index.js
@@ -328,6 +328,7 @@ describe('big-json', function() {
         it('should parse root JSON array', function(done) {
             const input = [{ key: 'value' }, { key: null }];
             json.parse({
+                isRootArray: true,
                 body: JSON.stringify(input)
             })
                 .then(function(pojo) {

--- a/test/index.js
+++ b/test/index.js
@@ -291,6 +291,7 @@ describe('big-json', function() {
                 }
             );
         });
+
         it('should return err in parse async (promise)', function(done) {
             json.parse({
                 body: fs
@@ -301,6 +302,17 @@ describe('big-json', function() {
                 assert.include(err.message, 'Invalid JSON (Unexpected');
                 return done();
             });
+        });
+
+        it('should parse (buffer)', function(done) {
+            json.parse({
+                body: Buffer.from(JSON.stringify(POJO))
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, POJO);
+                    return done();
+                })
+                .catch(done);
         });
     });
 });


### PR DESCRIPTION
Not much to say, very similar pr to #20, just added the option `isRootArray` to `createParseStream` and `parse`.
Would be sick if we can get this merged :)