### PR TITLE
feat: support auto detection of array as the primary root object

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ stringifyStream.on('data', function(strChunk) {
 
 ## API
 
-### createParseStream()
+### createParseStream(isRootArray)
+
+* `isRootArray` {Boolean} if true, stream will parse to Array, otherwise to Object
 
 __Returns__: {Stream} a JSON.parse stream
 
@@ -95,9 +97,10 @@ callback is not passed, a promise is returned.
 
 * `opts` {Object} an options object
 * `opts.body` {String | Buffer} the string or buffer to be parsed
+* `opts.isRootArray` {Boolean} if true, function will return Array
 * `callback` {Function} a callback object
 
-__Returns__: {Object} the parsed object
+__Returns__: {Object | Array} the parsed JSON
 
 ### stringify(opts, [callback])
 An async JSON.stringify using the same underlying stream implementation. If a

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ stringifyStream.on('data', function(strChunk) {
 
 ## API
 
-### createParseStream(isRootArray)
-
-* `isRootArray` {Boolean} if true, stream will parse to Array, otherwise to Object
+### createParseStream()
+Parses an incoming stream and accumulates it into a POJO. Supports both objects
+and arrays as root objects for stream data.
 
 __Returns__: {Stream} a JSON.parse stream
 
@@ -97,7 +97,6 @@ callback is not passed, a promise is returned.
 
 * `opts` {Object} an options object
 * `opts.body` {String | Buffer} the string or buffer to be parsed
-* `opts.isRootArray` {Boolean} if true, function will return Array
 * `callback` {Function} a callback object
 
 __Returns__: {Object | Array} the parsed JSON

--- a/api.md
+++ b/api.md
@@ -45,7 +45,7 @@ stream based JSON.parse. async function signature to abstract over streams.
     -   `opts.body` **([String][12] \| [Buffer][13])** string or buffer to parse
 -   `callback` **[Function][14]** a callback function
 
-Returns **[Object][11]** the parsed JSON object
+Returns **([Object][11] \| [Array][15])** the parsed JSON
 
 ## parse
 
@@ -59,7 +59,7 @@ variadic arguments to support both promise and callback based usage.
 -   `callback` **[Function][14]?** a callback function. if empty, returns a
     promise.
 
-Returns **[Object][11]** the parsed JSON object
+Returns **([Object][11] \| [Array][15])** the parsed JSON
 
 ## stringify
 
@@ -101,3 +101,5 @@ Returns **[Object][11]** the parsed JSON object
 [13]: https://nodejs.org/api/buffer.html
 
 [14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+
+[15]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,13 +25,14 @@ const _stringifyPromisified = util.promisify(_stringify);
  * The advantage of this approach is that by also using a streams interface,
  * any JSON parsing or stringification of large objects won't block the CPU.
  * @public
+ * @param {Boolean} isRootArray if true, stream will parse to Array, otherwise to Object
  * @function createParseStream
  * @return {Stream}
  */
-function createParseStream() {
+function createParseStream(isRootArray = false) {
     // when the parse stream gets chunks of data, it is an object with key/val
     // fields. accumulate the parsed fields.
-    let accumulator = {};
+    let accumulator = null;
     const parseStream = JSONStream.parse('$*');
     const wrapperStream = through2.obj(
         function write(chunk, enc, cb) {
@@ -46,19 +47,9 @@ function createParseStream() {
         }
     );
 
-    const initAccumulator = function(chunk) {
-        if (typeof chunk.key === 'number') {
-            return [];
-        }
-        return {};
-    };
-
-    // for each chunk parsed, add it to the accumulator
-    let dataChunkCounter = 0;
     parseStream.on('data', function(chunk) {
-        dataChunkCounter++;
-        if (dataChunkCounter === 1) {
-            accumulator = initAccumulator(chunk);
+        if (accumulator === null) {
+            accumulator = isRootArray ? [] : {};
         }
         accumulator[chunk.key] = chunk.value;
     });
@@ -93,9 +84,10 @@ function createStringifyStream(opts) {
  * stream based JSON.parse. async function signature to abstract over streams.
  * @public
  * @param {Object} opts options to pass to parse stream
+ * @param {Boolean} opts.isRootArray if true, function will return Array
  * @param {String|Buffer} opts.body string or buffer to parse
  * @param {Function} callback a callback function
- * @return {Object} the parsed JSON object
+ * @return {Object|Array} the parsed JSON
  */
 function _parse(opts, callback) {
     assert.object(opts, 'opts');
@@ -106,7 +98,7 @@ function _parse(opts, callback) {
     assert.func(callback, 'callback');
 
     const sourceStream = intoStream(opts.body);
-    const parseStream = createParseStream();
+    const parseStream = createParseStream(opts.isRootArray);
     const cb = once(callback);
 
     parseStream.on('data', function(data) {
@@ -126,10 +118,11 @@ function _parse(opts, callback) {
  * @public
  * @function parse
  * @param {Object} opts options to pass to parse stream
+ * @param {Boolean} opts.isRootArray if true, function will return Array
  * @param {String} opts.body string to parse
  * @param {Function} [callback] a callback function. if empty, returns a
  * promise.
- * @return {Object} the parsed JSON object
+ * @return {Object|Array} the parsed JSON
  */
 function parse(opts, callback) {
     // if more than one argument was passed, assume it's a callback based usage.

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ const _stringifyPromisified = util.promisify(_stringify);
 function createParseStream() {
     // when the parse stream gets chunks of data, it is an object with key/val
     // fields. accumulate the parsed fields.
-    const accumulator = {};
+    let accumulator = {};
     const parseStream = JSONStream.parse('$*');
     const wrapperStream = through2.obj(
         function write(chunk, enc, cb) {
@@ -46,8 +46,20 @@ function createParseStream() {
         }
     );
 
+    const initAccumulator = function(chunk) {
+        if (typeof chunk.key === 'number') {
+            return [];
+        }
+        return {};
+    };
+
     // for each chunk parsed, add it to the accumulator
+    let dataChunkCounter = 0;
     parseStream.on('data', function(chunk) {
+        dataChunkCounter++;
+        if (dataChunkCounter === 1) {
+            accumulator = initAccumulator(chunk);
+        }
         accumulator[chunk.key] = chunk.value;
     });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,17 +25,33 @@ const _stringifyPromisified = util.promisify(_stringify);
  * The advantage of this approach is that by also using a streams interface,
  * any JSON parsing or stringification of large objects won't block the CPU.
  * @public
- * @param {Boolean} isRootArray if true, stream will parse to Array, otherwise to Object
- * @function createParseStream
  * @return {Stream}
  */
-function createParseStream(isRootArray = false) {
+function createParseStream() {
     // when the parse stream gets chunks of data, it is an object with key/val
     // fields. accumulate the parsed fields.
     let accumulator = null;
     const parseStream = JSONStream.parse('$*');
     const wrapperStream = through2.obj(
         function write(chunk, enc, cb) {
+            // try to be clever (oh noes). assume we parse objects by default.
+            // if the stream starts and it looks like an array, set the
+            // starting value of the accumulator to an array. we opt into the
+            // array, with default accumulator as an object. this introduces
+            // less risk with this feature for any unexpected circumstances
+            // (hopefully).
+            if (accumulator === null) {
+                const chunkStr = chunk.toString(enc).trim();
+                // if the trimmed chunk is an empty string, delay initialization
+                // of the accumulator till we get something meaningful
+                if (chunkStr !== '') {
+                    if (chunkStr.charAt(0) === '[') {
+                        accumulator = [];
+                    } else {
+                        accumulator = {};
+                    }
+                }
+            }
             parseStream.write(chunk);
             return cb();
         },
@@ -48,9 +64,7 @@ function createParseStream(isRootArray = false) {
     );
 
     parseStream.on('data', function(chunk) {
-        if (accumulator === null) {
-            accumulator = isRootArray ? [] : {};
-        }
+        // this syntax should work when accumulator is object or array
         accumulator[chunk.key] = chunk.value;
     });
 
@@ -84,7 +98,6 @@ function createStringifyStream(opts) {
  * stream based JSON.parse. async function signature to abstract over streams.
  * @public
  * @param {Object} opts options to pass to parse stream
- * @param {Boolean} opts.isRootArray if true, function will return Array
  * @param {String|Buffer} opts.body string or buffer to parse
  * @param {Function} callback a callback function
  * @return {Object|Array} the parsed JSON
@@ -98,7 +111,7 @@ function _parse(opts, callback) {
     assert.func(callback, 'callback');
 
     const sourceStream = intoStream(opts.body);
-    const parseStream = createParseStream(opts.isRootArray);
+    const parseStream = createParseStream();
     const cb = once(callback);
 
     parseStream.on('data', function(data) {
@@ -118,7 +131,6 @@ function _parse(opts, callback) {
  * @public
  * @function parse
  * @param {Object} opts options to pass to parse stream
- * @param {Boolean} opts.isRootArray if true, function will return Array
  * @param {String} opts.body string to parse
  * @param {Function} [callback] a callback function. if empty, returns a
  * promise.

--- a/test/index.js
+++ b/test/index.js
@@ -211,7 +211,7 @@ describe('big-json', function() {
                 return done();
             });
 
-            parseStream.write('{ "');
+            parseStream.write('{"');
             parseStream.write(Buffer.from([0xe9, 0x81]));
             parseStream.write(Buffer.from([0x99]));
             parseStream.write('":"');
@@ -328,42 +328,10 @@ describe('big-json', function() {
         it('should parse root JSON Object as Object', function(done) {
             const input = { 0: { key: 'value' }, 1: { key: null } };
             json.parse({
-                isRootArray: false,
                 body: JSON.stringify(input)
             })
                 .then(function(pojo) {
                     assert.deepEqual(pojo, input);
-                    return done();
-                })
-                .catch(done);
-        });
-
-        it('should parse root JSON Object as Array', function(done) {
-            const input = { 0: { key: 'value' }, 1: { key: null } };
-            const expectedOutput = [{ key: 'value' }, { key: null }];
-            json.parse({
-                isRootArray: true,
-                body: JSON.stringify(input)
-            })
-                .then(function(pojo) {
-                    assert.deepEqual(pojo, expectedOutput);
-                    return done();
-                })
-                .catch(done);
-        });
-
-        it('should parse root JSON Array as Object', function(done) {
-            const input = [{ key: 'value' }, { key: null }];
-            const expectedOutput = {
-                0: { key: 'value' },
-                1: { key: null }
-            };
-            json.parse({
-                isRootArray: false,
-                body: JSON.stringify(input)
-            })
-                .then(function(pojo) {
-                    assert.deepEqual(pojo, expectedOutput);
                     return done();
                 })
                 .catch(done);
@@ -372,7 +340,6 @@ describe('big-json', function() {
         it('should parse root JSON Array as Array', function(done) {
             const input = [{ key: 'value' }, { key: null }];
             json.parse({
-                isRootArray: true,
                 body: JSON.stringify(input)
             })
                 .then(function(pojo) {
@@ -380,6 +347,36 @@ describe('big-json', function() {
                     return done();
                 })
                 .catch(done);
+        });
+
+        it('should determine correct root object with leading whitespace', function(done) {
+            const parseStream = json.createParseStream();
+
+            parseStream.on('data', function(pojo) {
+                assert.deepEqual(pojo, {
+                    foo: 'bar'
+                });
+                return done();
+            });
+
+            parseStream.write('\n\n    \n');
+            parseStream.write('\n\n    {');
+            parseStream.write('"foo": "bar"');
+            parseStream.end('\n\n    }"');
+        });
+
+        it('should determine correct root array with leading whitespace', function(done) {
+            const parseStream = json.createParseStream();
+
+            parseStream.on('data', function(pojo) {
+                assert.deepEqual(pojo, [0, 1, 2]);
+                return done();
+            });
+
+            parseStream.write('\n\n    \n');
+            parseStream.write('\n\n    [');
+            parseStream.write('0, 1, 2');
+            parseStream.end('\n\n    ]"');
         });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -324,5 +324,17 @@ describe('big-json', function() {
                 return done();
             });
         });
+
+        it('should parse root JSON array', function(done) {
+            const input = [{ key: 'value' }, { key: null }];
+            json.parse({
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, input);
+                    return done();
+                })
+                .catch(done);
+        });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -325,7 +325,51 @@ describe('big-json', function() {
             });
         });
 
-        it('should parse root JSON array', function(done) {
+        it('should parse root JSON Object as Object', function(done) {
+            const input = { 0: { key: 'value' }, 1: { key: null } };
+            json.parse({
+                isRootArray: false,
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, input);
+                    return done();
+                })
+                .catch(done);
+        });
+
+        it('should parse root JSON Object as Array', function(done) {
+            const input = { 0: { key: 'value' }, 1: { key: null } };
+            const expectedOutput = [{ key: 'value' }, { key: null }];
+            json.parse({
+                isRootArray: true,
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, expectedOutput);
+                    return done();
+                })
+                .catch(done);
+        });
+
+        it('should parse root JSON Array as Object', function(done) {
+            const input = [{ key: 'value' }, { key: null }];
+            const expectedOutput = {
+                0: { key: 'value' },
+                1: { key: null }
+            };
+            json.parse({
+                isRootArray: false,
+                body: JSON.stringify(input)
+            })
+                .then(function(pojo) {
+                    assert.deepEqual(pojo, expectedOutput);
+                    return done();
+                })
+                .catch(done);
+        });
+
+        it('should parse root JSON Array as Array', function(done) {
             const input = [{ key: 'value' }, { key: null }];
             json.parse({
                 isRootArray: true,

--- a/test/index.js
+++ b/test/index.js
@@ -328,6 +328,7 @@ describe('big-json', function() {
         it('should parse root JSON array', function(done) {
             const input = [{ key: 'value' }, { key: null }];
             json.parse({
+                isRootArray: true,
                 body: JSON.stringify(input)
             })
                 .then(function(pojo) {


### PR DESCRIPTION
Builds on #20 and #22 with a slightly different take. It relies on JSONStream's initial chunk to determine if the root object is an array or object. I'm actually not sure if this is a truly safe assumption, but my guiding thinking here is:

* Do the right thing automatically without the need to pass in an option
* Sometimes you may not know the correct stream format to use ahead of time (though arguably for the niche use case of this module you probably do know the format)

Caveat: this presumes that most people aren't looking to (accidentally) convert a POJO into an array and vice versa, as the previous implementation of this PR would allow. I think this is the right trade-off for a more opinionated approach. 