### PR TITLE
BREAKING CHANGE: updating deps, dropping older Node.js versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // core modules
-const stream = require('stream');
+const { PassThrough } = require('stream');
 const util = require('util');
 
 // external modules
@@ -10,7 +10,7 @@ const intoStream = require('into-stream');
 const JSONStream = require('JSONStream');
 const through2 = require('through2');
 const once = require('once').strict;
-const JsonStreamStringify = require('json-stream-stringify');
+const { JsonStreamStringify } = require('json-stream-stringify');
 
 // promisified implementations of callback APIs.
 const _parsePromisified = util.promisify(_parse);
@@ -160,7 +160,7 @@ function _stringify(opts, callback) {
 
     let stringified = '';
     const stringifyStream = createStringifyStream(opts);
-    const passthroughStream = new stream.PassThrough();
+    const passthroughStream = new PassThrough();
     const cb = once(callback);
 
     // setup the passthrough stream as a sink

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   },
   "dependencies": {
     "assert-plus": "^1.0.0",
-    "into-stream": "^5.1.0",
-    "json-stream-stringify": "^2.0.1",
+    "into-stream": "^6.0.0",
+    "json-stream-stringify": "^3.0.0",
     "JSONStream": "^1.3.1",
     "once": "^1.4.0",
-    "through2": "^3.0.1"
+    "through2": "^4.0.2"
   }
 }


### PR DESCRIPTION
Some of the updated deps bumps required node versions (v12+). No breaking API changes. 