### PR TITLE
- Intellisense for Stream type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,12 @@ const _parsePromisified = util.promisify(_parse);
 const _stringifyPromisified = util.promisify(_stringify);
 
 /**
+ * Nodejs stream
+ * @typedef {stream} Stream
+ */
+
+
+/**
  * Create a JSON.parse that uses a stream interface. The underlying
  * implementation is handled by JSONStream. This is merely a thin wrapper for
  * convenience that handles the reconstruction/accumulation of each

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "big-json",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "lib/index.js",
   "description": "A stream based implementation of JSON.parse and JSON.stringify for big POJOs",
   "homepage": "https://github.com/DonutEspresso/big-json",


### PR DESCRIPTION
IntelliSense was not working for stream.
Node: 16,18
Added

```
/**
 * Nodejs stream
 * @typedef {stream} Stream
 */
```

So `stream` and `Steam` will refer to the same type

<img width="327" alt="image" src="https://github.com/DonutEspresso/big-json/assets/24456144/4ed59c00-53fd-443a-b267-53376fa56254">
